### PR TITLE
build: :package: update release workflow with permissions and GoReleaser v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 name: Release
 
 on:
-  pull_request:
-  push:
+    pull_request:
+    push:
+      tags:
+        - "v*.*.*"
+
+permissions:
+  contents: write
 
 jobs:
   goreleaser:
@@ -12,20 +17,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ">=1.22.5"
-
-      - name: Run tests
-        run: go test ./...
-
+          go-version: stable
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for releases, specifically in the `release.yml` file. The main changes involve adding tag-based triggers, updating permissions, and modifying job steps to use more current versions and configurations.

Workflow updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R6-R10): Added tag-based triggers for the workflow to run on pushes to tags matching the pattern `v*.*.*`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R6-R10): Added permissions to allow writing contents.

Job configuration updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R28): Updated the Go setup step to use the stable version instead of a specific version.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R28): Removed the test running step.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R28): Updated the GoReleaser action to use version 6 and specified the version constraint `~> v2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated release workflow to trigger on specific tag patterns.
	- Enhanced permissions for content access in the release process.
	- Specified stable Go version for setup.
	- Updated GoReleaser action to a more specific version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->